### PR TITLE
Use login shell to install gems

### DIFF
--- a/tasks/rbenv.yml
+++ b/tasks/rbenv.yml
@@ -12,5 +12,6 @@
    rbenv global {{ rbenv_ruby_version }}
 - file: state=directory path={{ rbenv_root }}/versions/{{ rbenv_ruby_version }}/etc owner=root group=root mode=0755
 - copy: src=gemrc dest={{ rbenv_root }}/versions/{{ rbenv_ruby_version }}/etc/gemrc owner=root group=root mode=0644
-- gem: name=rbenv-rehash user_install=no executable={{ rbenv_root }}/shims/gem
-- gem: name=bundler user_install=no executable={{ rbenv_root }}/shims/gem
+- command: bash -lc "{{rbenv_root}}/shims/gem install rbenv-rehash"
+- command: bash -lc "{{rbenv_root}}/shims/gem install bundler"
+


### PR DESCRIPTION
When running this role, I found that my rbenv did not actually install any gems. A bit of googling suggested that using bash -lc was a more reliable way of installing gems into rbenv so I've had a go with this, and it seems to work.

Have you had any trouble with this? If so, this seems to be a fix. If not, I'd love to know if the gem module works correctly for you!

Thanks for writing the role, I've found it really useful.
